### PR TITLE
Add a password prompt

### DIFF
--- a/auth0-password-grant
+++ b/auth0-password-grant
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # auth0-password-grant - programmatically retrieve an Auth0 access token using the password grant
 VERSION=1.0.6
 
@@ -16,7 +16,7 @@ then
   . "$CONFIG_PATH/config"
 fi
 
-while getopts "vCBXu:p:a:c:r:d:" opt
+while getopts "vCBXPu:p:a:c:r:d:" opt
 do
   case "$opt" in
     v)  echo "auth0-password-grant version $VERSION"
@@ -28,6 +28,9 @@ do
     B)  BEARER=1
         ;;
     X)  CLIP=1
+        ;;
+    P)  read -s -p "Password: " PASSWORD
+        printf "\n"
         ;;
     u)  USER_NAME="$OPTARG"
         ;;


### PR DESCRIPTION
I changed the shebang line  to use `bash` instead of `sh` since `sh` has no support for `read -s`.

Verified to work on ubuntu, centos, arch and the latest macos